### PR TITLE
feat: added proxy for requests to OpenAI API

### DIFF
--- a/nodes/LmChatOpenAiLangfuse/LmChatOpenAiLangfuse.node.ts
+++ b/nodes/LmChatOpenAiLangfuse/LmChatOpenAiLangfuse.node.ts
@@ -18,6 +18,7 @@ import {
 import { formatBuiltInTools, prepareAdditionalResponsesParams } from './helpers/common';
 import { searchModels } from './methods/loadModels';
 import { N8nLlmTracing } from './N8nLlmTracing';
+import getProxyAgent from './helpers/httpProxyAgent'
 
 export class LmChatOpenAiLangfuse implements INodeType {
 	methods = {
@@ -597,6 +598,15 @@ export class LmChatOpenAiLangfuse implements INodeType {
 			configuration.baseURL = options.baseURL as string;
 		}
 
+		const timeout = (options.timeout as number) ?? 60000;
+
+		configuration.fetchOptions = {
+			dispatcher: getProxyAgent(configuration.baseURL ?? 'https://api.openai.com/v1', {
+				headersTimeout: timeout,
+				bodyTimeout: timeout,
+			}),
+		};
+
 		const includedOptions = pick(options, [
 			'frequencyPenalty',
 			'maxTokens',
@@ -837,7 +847,7 @@ export class LmChatOpenAiLangfuse implements INodeType {
 			apiKey: credentials.apiKey as string,
 			model: modelName,
 			...includedOptions,
-			timeout: (options.timeout as number) ?? 60000,
+			timeout,
 			maxRetries: (options.maxRetries as number) ?? 2,
 			configuration,
 			callbacks,

--- a/nodes/LmChatOpenAiLangfuse/helpers/httpProxyAgent.ts
+++ b/nodes/LmChatOpenAiLangfuse/helpers/httpProxyAgent.ts
@@ -1,0 +1,37 @@
+import proxyFromEnv from 'proxy-from-env';
+import { Agent, ProxyAgent } from 'undici';
+
+export interface AgentTimeoutOptions {
+    headersTimeout?: number;
+    bodyTimeout?: number;
+    connectTimeout?: number;
+}
+
+const DEFAULT_TIMEOUT = parseInt(process.env.N8N_AI_TIMEOUT_MAX ?? '3600000', 10);
+
+/**
+ * Returns an Agent (no proxy with timeout options) or ProxyAgent (with proxy) configured with timeouts,
+ * or undefined if no proxy is configured and no timeout options are provided.
+ */
+function getProxyAgent(targetUrl?: string, timeoutOptions?: AgentTimeoutOptions) {
+    const proxyUrl = proxyFromEnv.getProxyForUrl(targetUrl ?? 'https://example.nonexistent/');
+
+    const agentOptions = {
+        headersTimeout: timeoutOptions?.headersTimeout ?? DEFAULT_TIMEOUT,
+        bodyTimeout: timeoutOptions?.bodyTimeout ?? DEFAULT_TIMEOUT,
+        ...(timeoutOptions?.connectTimeout !== undefined && {
+            connectTimeout: timeoutOptions.connectTimeout,
+        }),
+    };
+
+    if (!proxyUrl) {
+        if (timeoutOptions) {
+            return new Agent(agentOptions);
+        }
+        return undefined;
+    }
+
+    return new ProxyAgent({ uri: proxyUrl, ...agentOptions });
+}
+
+export default getProxyAgent

--- a/nodes/LmChatOpenAiLangfuse/methods/loadModels.ts
+++ b/nodes/LmChatOpenAiLangfuse/methods/loadModels.ts
@@ -1,5 +1,6 @@
 import type { ILoadOptionsFunctions, INodeListSearchResult } from 'n8n-workflow';
 import OpenAI from 'openai';
+import getProxyAgent from '../helpers/httpProxyAgent'
 
 const shouldIncludeModel = (modelId: string, isCustomAPI: boolean): boolean => {
 	if (isCustomAPI) return true;
@@ -24,6 +25,9 @@ export async function searchModels(
 	const openai = new OpenAI({
 		baseURL,
 		apiKey: credentials.apiKey as string,
+		fetchOptions: {
+			dispatcher: getProxyAgent(baseURL),
+		},
 	});
 	const { data: models = [] } = await openai.models.list();
 

--- a/package.json
+++ b/package.json
@@ -56,12 +56,15 @@
     "langfuse": "^3.38.6",
     "langfuse-langchain": "^3.38.6",
     "lodash": "^4.17.21",
-    "openai": "^6.9.1"
+    "openai": "^6.9.1",
+    "proxy-from-env": "^2.0.0",
+    "undici": "^7.22.0"
   },
   "devDependencies": {
     "@types/jest": "^29.5.14",
     "@types/lodash": "^4.17.21",
     "@types/node": "^22.10.2",
+    "@types/proxy-from-env": "^1.0.4",
     "dotenv": "^17.2.3",
     "eslint": "^9.17.0",
     "eslint-config-prettier": "^9.1.0",


### PR DESCRIPTION
Hi!
You've created a great node for n8n!

But there's a problem: there's no support for the environment variable for setting proxies ("http_proxy", "https_proxy"), as in the default implementation.

In my pull request, I added a feature similar to the one implemented in the default node. Now the node can use proxies for requests (if the "http_proxy" and "https_proxy" environment variable are specified).